### PR TITLE
Added the ability to include sender data, I think.

### DIFF
--- a/sendwithus.js
+++ b/sendwithus.js
@@ -1,4 +1,3 @@
-
 var API = require('./lib/api');
 
 var Sendwithus = function(key, options) {
@@ -6,13 +5,14 @@ var Sendwithus = function(key, options) {
 };
 
 Sendwithus.prototype = {
-    send: function(email_id, recipient, data) {
+    send: function(email_id, recipient, data, sender) {
         var endpoint = 'send';
 
         var payload = {
             email_id: email_id,
             recipient: recipient,
-            email_data: data
+            email_data: data,
+            sender: sender
         };
 
         return this.api.post(endpoint, payload);


### PR DESCRIPTION
Based on [the docs](https://www.sendwithus.com/docs#api-send:rest) it looks like there's one property in the context that isn't included. Adding it, though perhaps it may be better for the function to just take one 'payload' argument instead?
