### PR TITLE
Updated restler library to latest (3.2.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "transactional"
   ],
   "dependencies": {
-    "restler": "~2.0.1"
+    "restler": "~3.2.2"
   },
   "devDependencies": {
     "nodeunit": ">=0.5.0"


### PR DESCRIPTION
I ran into some EventEmitter issues that stem from the Restler library:

![eventemitter_issue](https://cloud.githubusercontent.com/assets/703800/2791192/8cc55970-cbc4-11e3-8285-b9daa847f643.jpg)

This has been [fixed in the latest version of restler](https://github.com/danwrong/restler/issues/129), so I have updated and run the tests on my fork and everything passes. :)

![sendwithus-updated](https://cloud.githubusercontent.com/assets/703800/2791233/e5973960-cbc4-11e3-9030-61b9560bb86c.png)

Thanks for the library
