### PR TITLE
Upgrade restler dependency to 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "transactional"
   ],
   "dependencies": {
-    "restler": "~3.2.2"
+    "restler": "~3.4.0"
   },
   "devDependencies": {
     "nodeunit": "^0.9.1"


### PR DESCRIPTION
* Performing `restler` version update as described in [this issue](https://github.com/sendwithus/sendwithus_nodejs/issues/22)
  * dependency goes from `~3.2.2` to `~3.4.0`
* The underlying nsp vulnerability goes away once `restler` is updated to `3.4.0`
* The tests still pass with the new version of `restler`
  * This is expected as the update is minor, not major

Please let me know if you need anything else. I believe this a very straight-forward and risk-free change. 