### PR TITLE
Fix #64

### DIFF
--- a/lib/sendwithus.js
+++ b/lib/sendwithus.js
@@ -123,7 +123,7 @@ Sendwithus.prototype._handleResponse = function (result, response, callback) {
     this.emit("response", response.status, result, response);
     this._debug(`Response ${response.status}: ` + JSON.stringify(result));
     if (typeof callback == "function") {
-      callback(null, result);
+      callback(null, result, response);
     }
   } 
   // handle anything which is an error outside of the instaceof Error type

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sendwithus",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "author": "Sendwithus <us@sendwithus.com>",
   "description": "Sendwithus.com Node.js client",
   "main": "index.js",


### PR DESCRIPTION
## Description
Adds the response object to the success condition callback to fix #64 

## Motivation and Context
We were missing the response obj when chaining `.then()'s` which was causing issues when accessing response.

## How Has This Been Tested?
Tests have been run. Manual testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
