### PR TITLE
Fix deactivate drip campaign

### DIFF
--- a/lib/sendwithus.js
+++ b/lib/sendwithus.js
@@ -231,7 +231,7 @@ Sendwithus.prototype.dripCampaignDeactivate = function (
   var url = this._buildUrl("drip_campaigns", drip_campaign_id, "deactivate");
   var options = this._getOptions();
   this.emit("request", "POST", url, options.headers, data);
-  this._fetch(callback).del(url, options);
+  this._fetch(callback).postJson(url, data, options);
 };
 
 Sendwithus.prototype.dripCampaignDeactivateAll = function (data, callback) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "sendwithus",
-  "version": "6.0.1",
+  "version": "6.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sendwithus",
-      "version": "6.0.1",
+      "version": "6.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "node-fetch": "^2.6.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sendwithus",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "author": "Sendwithus <us@sendwithus.com>",
   "description": "Sendwithus.com Node.js client",
   "main": "index.js",

--- a/test/test.js
+++ b/test/test.js
@@ -316,7 +316,12 @@ describe("Customers Endpoint", function () {
 describe("Drip Campaigns Endpoint", function () {
   beforeEach(function () {
     this.sendwithus = sendwithusFactory(API_KEY);
-    this.recipientData = {
+    this.recipientActivateData = {
+      recipient: {
+        address: "customer@example.com",
+      }
+    };
+    this.recipientDeactivateData = {
       recipient_address: "customer@example.com",
     };
   });
@@ -336,7 +341,7 @@ describe("Drip Campaigns Endpoint", function () {
   it("should activate a recipient successfully", function (done) {
     this.sendwithus.dripCampaignActivate(
       ENABLED_DRIP_ID,
-      this.recipientData,
+      this.recipientActivateData,
       function (err, result) {
         try {
           assert.ifError(err);
@@ -352,7 +357,7 @@ describe("Drip Campaigns Endpoint", function () {
   it("should return an error (400) when activating on an inactive drip campaign", function (done) {
     this.sendwithus.dripCampaignActivate(
       DISABLED_DRIP_ID,
-      this.recipientData,
+      this.recipientActivateData,
       function (err, response) {
         try {
           assert.ok(err, "Error was thrown");
@@ -373,7 +378,7 @@ describe("Drip Campaigns Endpoint", function () {
   it("should return an error (400) when activating on a drip campaign that does not exist", function (done) {
     this.sendwithus.dripCampaignActivate(
       FALSE_DRIP_ID,
-      this.recipientData,
+      this.recipientActivateData,
       function (err, response) {
         try {
           assert.ok(err, "Error was thrown");
@@ -391,13 +396,11 @@ describe("Drip Campaigns Endpoint", function () {
     );
   });
 
-  it.skip("should deactivate a recipient successfully", function (done) {
-    // SendWithUs currently returns a 405 METHOD NOT ALLOWED error for this endpoint.
+  it("should deactivate a recipient successfully", function (done) {
     this.sendwithus.dripCampaignDeactivate(
       ENABLED_DRIP_ID,
-      this.recipientData,
+      this.recipientDeactivateData,
       function (err, result) {
-        console.log(err)
         try {
           assert.ifError(err);
           assert.ok(result.success, "Response was successful");
@@ -411,7 +414,7 @@ describe("Drip Campaigns Endpoint", function () {
 
   it("should deactivate all drip campaigns for recipient successfully", function (done) {
     this.sendwithus.dripCampaignDeactivateAll(
-      this.recipientData,
+      this.recipientDeactivateData,
       function (err, result) {
         try {
           assert.ifError(err);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail if necessary -->
This PR fixes the drip campaign deactivate method. The [deactivate drip campaign endpoint](https://support.sendwithus.com/api/#deactivateacampaignforcustomer) expects a POST method and not a DELETE.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes the 405 "Method Not Allowed" error message.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->
Tested the changes with the patch and updated tests run successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
